### PR TITLE
fix(fetch): Replaced php short tag with <?php in fetch latest script.

### DIFF
--- a/fetchLatestSnapshot.php
+++ b/fetchLatestSnapshot.php
@@ -4,7 +4,7 @@
   </head>
 <body>
   <pre><?php echo `date`; ?></pre>
-  <pre><?
+  <pre><?php
     $ver = $_GET['ver'];
     $ciBase = 'http://ci.angularjs.org/job/angular.js-angular-v1.0.x/ws/build/';
     $url = $ciBase.'angular-'.$ver.'.zip';


### PR DESCRIPTION
Fast CGI running on Nginx does not support short tags by default, and this is typically not a setting that can be set at runtime. It's simpler to remove the requirement in code rather than force every environment's php config to support short_tags.
