### PR TITLE
Make 'T' delimiter optional in ISO8601 strings

### DIFF
--- a/1.4.0-rc.0/angular-scenario.js
+++ b/1.4.0-rc.0/angular-scenario.js
@@ -27615,7 +27615,7 @@ dateFilter.$inject = ['$locale'];
 function dateFilter($locale) {
 
 
-  var R_ISO8601_STR = /^(\d{4})-?(\d\d)-?(\d\d)(?:T(\d\d)(?::?(\d\d)(?::?(\d\d)(?:\.(\d+))?)?)?(Z|([+-])(\d\d):?(\d\d))?)?$/;
+  var R_ISO8601_STR = /^(\d{4})-?(\d\d)-?(\d\d)(?:[T ](\d\d)(?::?(\d\d)(?::?(\d\d)(?:\.(\d+))?)?)?(Z|([+-])(\d\d):?(\d\d))?)?$/;
                      // 1        2       3         4          5          6          7          8  9     10      11
   function jsonStringToDate(string) {
     var match;

--- a/1.4.0-rc.0/angular.js
+++ b/1.4.0-rc.0/angular.js
@@ -18423,7 +18423,7 @@ dateFilter.$inject = ['$locale'];
 function dateFilter($locale) {
 
 
-  var R_ISO8601_STR = /^(\d{4})-?(\d\d)-?(\d\d)(?:T(\d\d)(?::?(\d\d)(?::?(\d\d)(?:\.(\d+))?)?)?(Z|([+-])(\d\d):?(\d\d))?)?$/;
+  var R_ISO8601_STR = /^(\d{4})-?(\d\d)-?(\d\d)(?:[T ](\d\d)(?::?(\d\d)(?::?(\d\d)(?:\.(\d+))?)?)?(Z|([+-])(\d\d):?(\d\d))?)?$/;
                      // 1        2       3         4          5          6          7          8  9     10      11
   function jsonStringToDate(string) {
     var match;


### PR DESCRIPTION
According to Wikipedia’s article on the ISO 8601 format, the ’T’ delimiter is optional and can be omitted.  This allows PostgreSQL **datetime** strings to be filtered.

This was not supported before this patch: 
    {{ “2015-03-27 18:24:49.324101” | date:’short’ }} 

Even though this worked:
    var myDate = new Date('2015-03-27 18:24:49.324101')
    ...
    {{ myDate | date:'short' }}