### PR TITLE
Fixed bower install command

### DIFF
--- a/snapshot/docs/partials/api/ngCookies.html
+++ b/snapshot/docs/partials/api/ngCookies.html
@@ -20,7 +20,7 @@
     </li>
     <li>
       <a href="http://bower.io">Bower</a><br>
-      e.g. <pre><code>bower install angular-cookies@X.Y.Z</code></pre>
+      e.g. <pre><code>bower install angular-cookies#X.Y.Z</code></pre>
     </li>
     <li>
       <a href="http://code.angularjs.org/">code.angularjs.org</a><br>


### PR DESCRIPTION
The docs are using `@X.Y.Z` but bower expects `#X.Y.X`
